### PR TITLE
Update Togglz version to 2.6.1.Final

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -6,7 +6,7 @@ ext {
     jcip_annotations                 : '1.0',
     logback_classic                  : '1.2.3',
     javax_servlet_api                : '3.1.0',
-    togglz                           : '2.6.0.Final',
+    togglz                           : '2.6.1.Final',
     mongodb_driver                   : '3.8.0',
     mongodb_reactive_driver          : '1.9.0',
     caffeine                         : '2.5.6',


### PR DESCRIPTION
There is a runtime error when executing Spring tests with "spring-boot-starter-breuninger-togglz" which depends on Togglz 2.6.0.Final.

See:
* https://github.com/togglz/togglz/issues/282

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/e-breuninger/spring-boot-starter-breuninger/13)
<!-- Reviewable:end -->
